### PR TITLE
set default perl executable to $^X

### DIFF
--- a/lib/Test/AnyEvent/MySQL/CreateDatabase.pm
+++ b/lib/Test/AnyEvent/MySQL/CreateDatabase.pm
@@ -24,7 +24,7 @@ sub perl {
     }
     return $_[0]->{perl} ||= do {
         my $perl = file(__FILE__)->dir->parent->parent->parent->parent->file('perl');
-        -f $perl ? $perl->stringify : 'perl';
+        -f $perl ? $perl->stringify : $^X;
     };
 }
 


### PR DESCRIPTION
On some circumstance where `perl` executable not living in `PATH` is used, invoking Perl using `$^X` would be suitable.